### PR TITLE
p: devops: fix to publish to pypi

### DIFF
--- a/.github/workflows/opypackage-standard.yml
+++ b/.github/workflows/opypackage-standard.yml
@@ -10,6 +10,7 @@ jobs:
     uses: openergy/ogithub-actions/.github/workflows/opypackage-standard-v03.yml@master
     with:
       install-eplus-2210: true
+      publish-to-pypi: true
 
     secrets:
       AZURE_CONDA_CHANNEL_KEY: ${{ secrets.AZURE_CONDA_CHANNEL_KEY }}

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -5,6 +5,7 @@
     p: patch
 
 ## next
+* p: devops: fix to publish to pypi 
 
 ## 1.6.0
 * m: implementing DesignDay model from ddy  


### PR DESCRIPTION
@geoffroy-destaintot forgot the pypi input in github action, sorry! (yet other openergy packages depending on opyplus should work anyway)